### PR TITLE
Allow for docker capabilities to be added from cyborg

### DIFF
--- a/zun/container/docker/driver.py
+++ b/zun/container/docker/driver.py
@@ -343,6 +343,10 @@ class DockerDriver(driver.ContainerDriver):
                     # TODO: actually look up cgroups for access info
                     host_config['devices'].append(
                         f'{dev["path"]}:{dev["path"]}:rw')
+                host_config["cap_add"] = []
+                for cap_list in oci_config.get("capabilities", {}).values():
+                    for cap in cap_list:
+                        host_config["cap_add"].append(cap)
 
             kwargs['host_config'] = docker.create_host_config(**host_config)
 

--- a/zun/container/docker/driver.py
+++ b/zun/container/docker/driver.py
@@ -15,6 +15,7 @@ import datetime
 import errno
 import eventlet
 import functools
+import itertools
 import types
 
 from docker import errors
@@ -343,10 +344,9 @@ class DockerDriver(driver.ContainerDriver):
                     # TODO: actually look up cgroups for access info
                     host_config['devices'].append(
                         f'{dev["path"]}:{dev["path"]}:rw')
-                host_config["cap_add"] = []
-                for cap_list in oci_config.get("capabilities", {}).values():
-                    for cap in cap_list:
-                        host_config["cap_add"].append(cap)
+
+                capabilities = oci_config.get("capabilities", {})
+                host_config["cap_add"] = list(set(itertools.chain(*capabilities.values())))
 
             kwargs['host_config'] = docker.create_host_config(**host_config)
 

--- a/zun/container/oci.py
+++ b/zun/container/oci.py
@@ -14,15 +14,17 @@
 import copy
 from zun.tests.unit.scheduler.fake_loadables.fake_loadable1 import FakeLoadableSubClass1
 
+# The possible sets for capabilities, from the manual
+# https://man7.org/linux/man-pages/man7/capabilities.7.html
+CAP_SETS = ["bounding", "permitted", "inheritable", "effective", "ambient"]
 
 def merge_oci_runtime_config(parent, *cfgs):
-    cap_sets = ["bounding", "permitted", "inheritable", "effective", "ambient"]
     merged = copy.deepcopy(parent)
     env = merged.setdefault('process', {}).setdefault('env', [])
     mounts = merged.setdefault('mounts', [])
     devices = merged.setdefault('linux', {}).setdefault('devices', [])
     capabilities = merged.setdefault('capabilities', {})
-    for group in cap_sets:
+    for group in CAP_SETS:
         capabilities.setdefault(group, [])
     for cfg in cfgs:
         cfg_env = cfg.get('process', {}).get('env')
@@ -34,9 +36,9 @@ def merge_oci_runtime_config(parent, *cfgs):
         cfg_devices = cfg.get('linux', {}).get('devices')
         if cfg_devices is not None:
             devices.extend(cfg_devices)
-        cfg_capabilities = cfg.get('capabilities', {})
+        cfg_capabilities = cfg.get('linux', {}).get('capabilities')
         if cfg_capabilities is not None:
-            for group in cap_sets:
+            for group in CAP_SETS:
                 caps = cfg_capabilities.get(group, [])
                 for cap in caps:
                     if cap not in capabilities[group]:


### PR DESCRIPTION
Any linux capabilities included in the OCI config from cyborg will be included in the docker host config. The specific capability sets are ignored, if a capability appears in any of these, it is added to the container.