### PR TITLE
Add support for get/put archive

### DIFF
--- a/zun/conf/k8s.py
+++ b/zun/conf/k8s.py
@@ -36,6 +36,13 @@ k8s_opts = [
     cfg.IntOpt('execute_timeout',
                default=5,
                help='Timeout in seconds for executing a command in a k8s pod.'),
+    cfg.IntOpt('archive_timeout',
+               default=120,
+               help=(
+                'Timeout in seconds for archive commands. Larger values make it '
+                'possible to upload/download larger sections of the file system, but '
+                'will lock up the K8s worker in the process.'
+               )),
 ]
 
 ALL_OPTS = (k8s_opts)

--- a/zun/container/k8s/exception.py
+++ b/zun/container/k8s/exception.py
@@ -1,0 +1,4 @@
+from zun.common import exception
+
+class K8sException(exception.ZunException):
+    message = "Failed to perform operation on K8s"

--- a/zun/container/k8s/volume.py
+++ b/zun/container/k8s/volume.py
@@ -20,7 +20,7 @@ class K8sConfigMap(VolumeDriver):
     @validate_volume_provider(supported_providers)
     def attach(self, context, volmap):
         LOG.debug("Creating configmap for volumes %s", volmap)
-        namespace = context.project_id
+        namespace = volmap.volume.project_id
         config_map = mapping.config_map(volmap)
         LOG.debug(config_map)
         try:
@@ -40,8 +40,9 @@ class K8sConfigMap(VolumeDriver):
     @validate_volume_provider(supported_providers)
     def detach(self, context, volmap):
         name = mapping.config_map_name(volmap)
+        namespace = volmap.volume.project_id
         try:
-            self.k8s_core_v1.delete_namespaced_config_map(name, context.project_id)
+            self.k8s_core_v1.delete_namespaced_config_map(name, namespace)
             LOG.info("Deleted configmap for volume %s", volmap.volume.uuid)
         except client.ApiException as exc:
             if exc.status == 404:


### PR DESCRIPTION
This should bring the K8s driver up to code w.r.t. get/put archive capability. This does require the `tar` binary be available in the container. This is also a limitation in kubectl and in Docker itself, don't think there's really any way around it w/ how containers work.