### PR TITLE
Add API endpoint to get device profile resources

### DIFF
--- a/zun/api/controllers/v1/__init__.py
+++ b/zun/api/controllers/v1/__init__.py
@@ -26,6 +26,7 @@ from zun.api.controllers import link
 from zun.api.controllers.v1 import availability_zone as a_zone
 from zun.api.controllers.v1 import capsules as capsule_controller
 from zun.api.controllers.v1 import containers as container_controller
+from zun.api.controllers.v1 import drivers as drivers_controller
 from zun.api.controllers.v1 import hosts as host_controller
 from zun.api.controllers.v1 import images as image_controller
 from zun.api.controllers.v1 import networks as network_controller
@@ -168,6 +169,7 @@ class Controller(controllers_base.Controller):
     quotas = quotas_controller.QuotaController()
     quota_classes = quota_classes_controller.QuotaClassController()
     registries = registries_controller.RegistryController()
+    drivers = drivers_controller.DriverController()
 
     @pecan.expose('json')
     def get(self):

--- a/zun/api/controllers/v1/drivers.py
+++ b/zun/api/controllers/v1/drivers.py
@@ -1,0 +1,21 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from zun.api.controllers import base
+from zun.container.k8s import controller as k8s_controller
+
+
+class DriverController(base.Controller):
+    """Host info controller"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.k8s = k8s_controller.K8sController()

--- a/zun/container/k8s/controller.py
+++ b/zun/container/k8s/controller.py
@@ -1,0 +1,17 @@
+from oslo_log import log as logging
+import pecan
+
+from zun.api.controllers import base
+from zun.common import exception
+from zun.container.k8s import mapping
+
+LOG = logging.getLogger(__name__)
+
+
+class K8sController(base.Controller):
+    @pecan.expose('json')
+    @exception.wrap_pecan_controller_exception
+    def device_profiles(self):
+        """Display configured device profiles and what K8s resources they map to.
+        """
+        return mapping.device_profile_resources()

--- a/zun/container/k8s/controller.py
+++ b/zun/container/k8s/controller.py
@@ -9,6 +9,10 @@ LOG = logging.getLogger(__name__)
 
 
 class K8sController(base.Controller):
+    _custom_actions = {
+        'device_profiles': ['GET'],
+    }
+
     @pecan.expose('json')
     @exception.wrap_pecan_controller_exception
     def device_profiles(self):


### PR DESCRIPTION
The output is specific to the k8s driver so this adds a new way for
drivers to register their own controller endpoints. They are under
the drivers/ prefix; this endpoint is at:

GET /drivers/k8s/device_profiles