### PR TITLE
Wip/ci unittests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Unit tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.7.13"
+          python-version: ${{ matrix.python-version }}
+      - name: Run tests
+        run: |
+          uvx \
+            --from 'tox' --with tox-uv \
+            tox -e "py${{ matrix.python-version }}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 minversion = 2.0
 envlist = py38,pep8,migration
-skipsdist = True
 
 [testenv]
 usedevelop = True
 install_command = pip install {opts} {packages}
-whitelist_externals = bash
+allowlist_externals = bash
                       find
                       rm
 setenv =
@@ -22,7 +21,13 @@ commands =
   stestr run {posargs}
   stestr slowest
 
-passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
+passenv =
+  http_proxy
+  HTTP_PROXY
+  https_proxy
+  HTTPS_PROXY
+  no_proxy
+  NO_PROXY
 
 [testenv:pep8]
 basepython = python3
@@ -63,7 +68,7 @@ commands =
 basepython = python3
 envdir = {toxworkdir}/docs
 deps = {[testenv:docs]deps}
-whitelist_externals =
+allowlist_externals =
   make
 commands =
   sphinx-build -W --keep-going -b latex doc/source doc/build/pdf
@@ -164,6 +169,8 @@ deps =
 # dependencies are missing! This also means that bindep must be installed
 # separately, outside of the requirements files.
 deps = bindep
+skipsdist=True
+usedevelop=False
 commands = bindep test
 
 [testenv:fullstack]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py38,pep8,migration
 
 [testenv]
 usedevelop = True
-install_command = pip install {opts} {packages}
 allowlist_externals = bash
                       find
                       rm

--- a/zun/compute/manager.py
+++ b/zun/compute/manager.py
@@ -328,7 +328,7 @@ class Manager(periodic_task.PeriodicTasks):
         finally:
             # If the driver is using async task completion, it will be responsible
             # for clearing the task_state itself.
-            if not self.driver.async_tasks:
+            if not getattr(self.driver, "async_tasks", None):
                 container.task_state = None
                 container.save(context)
 

--- a/zun/scheduler/filter_scheduler.py
+++ b/zun/scheduler/filter_scheduler.py
@@ -159,7 +159,7 @@ class FilterScheduler(driver.Scheduler):
             alloc_req = alloc_reqs_by_rp_uuid[host.uuid][0]
             host_state = dict(host=host.hostname, nodename=None,
                               limits=host.limits,
-                              resource_mappings=alloc_req["mappings"])
+                              resource_mappings=getattr(alloc_req, "mappings", []))
             dests.append(host_state)
 
         if len(dests) < 1:

--- a/zun/tests/unit/api/controllers/test_root.py
+++ b/zun/tests/unit/api/controllers/test_root.py
@@ -28,7 +28,7 @@ class TestRootController(api_base.FunctionalTest):
             'default_version':
             {'id': 'v1',
              'links': [{'href': 'http://localhost/v1/', 'rel': 'self'}],
-             'max_version': '1.40',
+             'max_version': '1.41',
              'min_version': '1.1',
              'status': 'CURRENT'},
             'description': 'Zun is an OpenStack project which '
@@ -37,7 +37,7 @@ class TestRootController(api_base.FunctionalTest):
             'versions': [{'id': 'v1',
                           'links': [{'href': 'http://localhost/v1/',
                                      'rel': 'self'}],
-                          'max_version': '1.40',
+                          'max_version': '1.41',
                           'min_version': '1.1',
                           'status': 'CURRENT'}]}
 

--- a/zun/tests/unit/scheduler/client/test_report.py
+++ b/zun/tests/unit/scheduler/client/test_report.py
@@ -2003,7 +2003,7 @@ class TestProviderOperations(SchedulerReportClientTestCase):
         expected_url = '/allocation_candidates?%s' % parse.urlencode(
             expected_query)
         self.ks_adap_mock.get.assert_called_once_with(
-            expected_url, microversion='1.31', endpoint_filter=mock.ANY,
+            expected_url, microversion='1.36', endpoint_filter=mock.ANY,
             logger=mock.ANY,
             headers={'X-Openstack-Request-Id': self.context.global_id})
         self.assertEqual(mock.sentinel.alloc_reqs, alloc_reqs)
@@ -2044,7 +2044,7 @@ class TestProviderOperations(SchedulerReportClientTestCase):
             expected_query)
         self.assertEqual(mock.sentinel.alloc_reqs, alloc_reqs)
         self.ks_adap_mock.get.assert_called_once_with(
-            expected_url, microversion='1.31', endpoint_filter=mock.ANY,
+            expected_url, microversion='1.36', endpoint_filter=mock.ANY,
             logger=mock.ANY,
             headers={'X-Openstack-Request-Id': self.context.global_id})
         self.assertEqual(mock.sentinel.p_sums, p_sums)
@@ -2067,7 +2067,7 @@ class TestProviderOperations(SchedulerReportClientTestCase):
         res = self.client.get_allocation_candidates(self.context, resources)
 
         self.ks_adap_mock.get.assert_called_once_with(
-            mock.ANY, microversion='1.31', endpoint_filter=mock.ANY,
+            mock.ANY, microversion='1.36', endpoint_filter=mock.ANY,
             logger=mock.ANY,
             headers={'X-Openstack-Request-Id': self.context.global_id})
         url = self.ks_adap_mock.get.call_args[0][0]


### PR DESCRIPTION
Add CI and unittests (using uv + tox-uv just for speedup)

fixes for failing unittests include several areas were we have bumped default api microversions, and places where we modified the manager to call methods that were only defiend on the k8s implementations, but not on base classes.