### PR TITLE
apply patch

### DIFF
--- a/zun/container/k8s/driver.py
+++ b/zun/container/k8s/driver.py
@@ -23,6 +23,7 @@ from websocket import ABNF
 from kubernetes import client, config, stream, watch
 from kubernetes.stream import stream
 from kubernetes.stream.ws_client import WSClient
+from kubernetes.client.models.v1_container_image import V1ContainerImage
 from oslo_log import log as logging
 from oslo_serialization import jsonutils
 from oslo_utils import units
@@ -45,6 +46,34 @@ STDERR_CHANNEL = 2
 # A fake "network id" for when we want to keep track of container
 # addresses but the driver is not configured to integrate w/ Neutron.
 UNDEFINED_NETWORK = "undefined_network"
+
+
+
+# https://github.com/kubernetes-client/python/issues/895
+# If a container image contains no tag or digest, patch/list
+# node requests sent via python Kubernetes client will be
+# returned with exception because python Kubernetes client
+# deserializes the ContainerImage response from kube-apiserver
+# and it fails the validation due to the empty image name.
+#
+# Implement this workaround to replace the V1ContainerImage.names
+# in the python Kubernetes client to bypass the "none image"
+# check because the error is not from kubernetes. If patching
+# a node with a new host label, we can see the label is
+# created successfully in Kubernetes.
+#
+# This workaround should be removed if the proposed solutions
+# can be made in kubernetes or a workaround can be implemented
+# in containerd.
+# https://github.com/kubernetes/kubernetes/pull/79018
+# https://github.com/containerd/containerd/issues/4771
+def names(self, names):
+    """Monkey patch V1ContainerImage with this to set the names."""
+    self._names = names
+
+# Replacing address of "names" in V1ContainerImage
+# with the "names" defined above
+V1ContainerImage.names = V1ContainerImage.names.setter(names)
 
 
 def is_exception_like(api_exc: client.ApiException, code=None, message_like=None, **kwargs):


### PR DESCRIPTION
periodic tasks were hanging on the same error as here https://review.opendev.org/c/starlingx/config/+/764098

https://github.com/kubernetes-client/python/issues/895
If a container image contains no tag or digest, patch/list
node requests sent via python Kubernetes client will be
returned with exception because python Kubernetes client
deserializes the ContainerImage response from kube-apiserver
and it fails the validation due to the empty image name.

Implement this workaround to replace the V1ContainerImage.names
in the python Kubernetes client to bypass the "none image"
check because the error is not from kubernetes. If patching
a node with a new host label, we can see the label is
created successfully in Kubernetes.

This workaround should be removed if the proposed solutions
can be made in kubernetes or a workaround can be implemented
in containerd.
https://github.com/kubernetes/kubernetes/pull/79018
https://github.com/containerd/containerd/issues/4771