### PR TITLE
Wip/add dev toggles

### DIFF
--- a/zun/conf/k8s.py
+++ b/zun/conf/k8s.py
@@ -66,7 +66,12 @@ k8s_opts = [
                help="The effect for the worker node taint to be tolerated"),
     cfg.BoolOpt('blazar_reservation_required',
                help="Whether containers can be scheduled without a reservation; useful for shared hosts.",
-               default=True)
+               default=True),
+    cfg.BoolOpt(
+        "mount_udev",
+        help="If true, mount /run/udev:ro into each container, allowing service like libcamera to watch for device changes.",
+        default=False,
+    ),
 ]
 
 ALL_OPTS = (k8s_opts)

--- a/zun/conf/k8s.py
+++ b/zun/conf/k8s.py
@@ -64,6 +64,9 @@ k8s_opts = [
                help="The value for the worker node taint to be tolerated"),
     cfg.StrOpt('worker_taint_effect',
                help="The effect for the worker node taint to be tolerated"),
+    cfg.BoolOpt('blazar_reservation_required',
+               help="Whether containers can be scheduled without a reservation; useful for shared hosts.",
+               default=True)
 ]
 
 ALL_OPTS = (k8s_opts)

--- a/zun/conf/k8s.py
+++ b/zun/conf/k8s.py
@@ -72,6 +72,11 @@ k8s_opts = [
         help="If true, mount /run/udev:ro into each container, allowing service like libcamera to watch for device changes.",
         default=False,
     ),
+    cfg.BoolOpt(
+        "forbid_control_plane",
+        help="If true, prevent user containers from launching on control plane nodes.",
+        default=True,
+    ),
 ]
 
 ALL_OPTS = (k8s_opts)

--- a/zun/container/k8s/mapping.py
+++ b/zun/container/k8s/mapping.py
@@ -281,6 +281,7 @@ def deployment(container, image, requested_volumes=None, image_pull_secrets=None
                 }
             },
         },
+    }
 
     # if forbid_control_plane and blazar_reservation_required are false,
     # this list will be empty. Setting afffinity to an empty list breaks

--- a/zun/container/k8s/mapping.py
+++ b/zun/container/k8s/mapping.py
@@ -158,14 +158,16 @@ def deployment(container, image, requested_volumes=None, image_pull_secrets=None
         LABELS["project_id"]: container.project_id,
     }
 
-    # Ensure user pods are never scheduled onto control plane infra
-    node_selector_expressions = [
-        {
-            "key": "node-role.kubernetes.io/control-plane",
-            "operator": "NotIn",
-            "values": ["true"]
-        },
-    ]
+    node_selector_expressions = []
+    if CONF.k8s.forbid_control_plane:
+        # Ensure user pods are never scheduled onto control plane infra
+        node_selector_expressions.append(
+            {
+                "key": "node-role.kubernetes.io/control-plane",
+                "operator": "NotIn",
+                "values": ["true"],
+            },
+        )
 
     reservation_id = container.annotations.get(utils.RESERVATION_ANNOTATION)
     if CONF.k8s.blazar_reservation_required:
@@ -246,17 +248,6 @@ def deployment(container, image, requested_volumes=None, image_pull_secrets=None
                     "labels": labels,
                 },
                 "spec": {
-                    "affinity": {
-                        "nodeAffinity": {
-                            "requiredDuringSchedulingIgnoredDuringExecution": {
-                                "nodeSelectorTerms": [
-                                    {
-                                        "matchExpressions": node_selector_expressions,
-                                    },
-                                ],
-                            },
-                        },
-                    },
                     "containers": [
                         {
                             "args": container.command,
@@ -290,7 +281,22 @@ def deployment(container, image, requested_volumes=None, image_pull_secrets=None
                 }
             },
         },
-    }
+
+    # if forbid_control_plane and blazar_reservation_required are false,
+    # this list will be empty. Setting afffinity to an empty list breaks
+    # scheduling
+    if node_selector_expressions:
+        deployment_spec["spec"]["template"]["spec"]["affinity"] = {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": node_selector_expressions,
+                        },
+                    ],
+                },
+            }
+        }
 
     if CONF.k8s.enable_worker_taint:
         validate_taint(key=CONF.k8s.worker_taint_key,

--- a/zun/container/k8s/mapping.py
+++ b/zun/container/k8s/mapping.py
@@ -170,22 +170,22 @@ def deployment(container, image, requested_volumes=None, image_pull_secrets=None
     reservation_id = container.annotations.get(utils.RESERVATION_ANNOTATION)
     if CONF.k8s.blazar_reservation_required:
         if reservation_id:
-        # Add the reservation ID to the deployment labels; this enables the reservation
-        # system to find the deployments tied to the reservation for cleanup.
-        deployment_labels[LABELS["blazar_reservation_id"]] = reservation_id
-        # Ensure the deployment lands on a reserved kubelet.
-        node_selector_expressions.extend([
-            {
-                "key": LABELS["blazar_project_id"],
-                "operator": "In",
-                "values": [container.project_id],
-            },
-            {
-                "key": LABELS["blazar_reservation_id"],
-                "operator": "In",
-                "values": [reservation_id],
-            }
-        ])
+            # Add the reservation ID to the deployment labels; this enables the reservation
+            # system to find the deployments tied to the reservation for cleanup.
+            deployment_labels[LABELS["blazar_reservation_id"]] = reservation_id
+            # Ensure the deployment lands on a reserved kubelet.
+            node_selector_expressions.extend([
+                {
+                    "key": LABELS["blazar_project_id"],
+                    "operator": "In",
+                    "values": [container.project_id],
+                },
+                {
+                    "key": LABELS["blazar_reservation_id"],
+                    "operator": "In",
+                    "values": [reservation_id],
+                }
+            ])
         else:
             """
             TODO: k8s driver does not currently support a "mixed" mode. Only 
@@ -197,19 +197,20 @@ def deployment(container, image, requested_volumes=None, image_pull_secrets=None
     volumes = []
     volume_mounts = []
 
-    volume_mounts.append({
-        "name": "udev",
-        "mountPath": "/run/udev",
-        "readOnly": True,
-    })
+    if CONF.k8s.mount_udev:
+        volume_mounts.append({
+            "name": "udev",
+            "mountPath": "/run/udev",
+            "readOnly": True,
+        })
 
-    volumes.append({
-        "name": "udev",
-        "hostPath": {
-            "path": "/run/udev",
-            "type": "Directory"
-        }
-    })
+        volumes.append({
+            "name": "udev",
+            "hostPath": {
+                "path": "/run/udev",
+                "type": "Directory"
+            }
+        })
 
     if requested_volumes:
         for volmap in requested_volumes.get(container.uuid, []):

--- a/zun/container/k8s/mapping.py
+++ b/zun/container/k8s/mapping.py
@@ -168,7 +168,8 @@ def deployment(container, image, requested_volumes=None, image_pull_secrets=None
     ]
 
     reservation_id = container.annotations.get(utils.RESERVATION_ANNOTATION)
-    if reservation_id:
+    if CONF.k8s.blazar_reservation_required:
+        if reservation_id:
         # Add the reservation ID to the deployment labels; this enables the reservation
         # system to find the deployments tied to the reservation for cleanup.
         deployment_labels[LABELS["blazar_reservation_id"]] = reservation_id
@@ -185,11 +186,13 @@ def deployment(container, image, requested_volumes=None, image_pull_secrets=None
                 "values": [reservation_id],
             }
         ])
-    else:
-        """ TODO: k8s driver does not currently support container launch without a reservation ID
-        If permitted, containers can spawn on already reserved nodes.
-        """
-        raise ReservationException(f"container {container.uuid} has no reservaton ID set.")
+        else:
+            """
+            TODO: k8s driver does not currently support a "mixed" mode. Only 
+            disable reservation requirement if no container hosts use reservations,
+            otherwise containers can spawn on already reserved nodes.
+            """
+            raise ReservationException(f"blazar_reservation_required is True, and container {container.uuid} has no reservaton ID.")
 
     volumes = []
     volume_mounts = []


### PR DESCRIPTION
We had hardcoded some scheduling parameters to ensure correct operation in production, but it's useful to relax these requirements when either blazar is not being used, or for use in an all-in-one dev context.

If `blazar_reservation_required` is false, the reservation_id will not be used to schedule pods.
If `forbid_control_plane` is false, we will skip adding a node affinity which would prevent launching on the a control-plane host.

Finally, `mount_udev` was hardcoded in a hacky way, and we need to disable this when running on a control-plane node due to differing paths between x86 and balena hosts. (this should really be set IFF the camera device profile is requested anyway...)