### PR TITLE
privileged must be defined per container now, not for the pod

### DIFF
--- a/zun/container/k8s/mapping.py
+++ b/zun/container/k8s/mapping.py
@@ -270,13 +270,15 @@ def deployment(container, image, requested_volumes=None, image_pull_secrets=None
                             "workingDir": container.workdir,
                             "resources": resources,
                             "livenessProbe": liveness_probe,
+                            "securityContext": {
+                                "privileged": container.privileged,
+                            },
                         }
                     ],
                     "hostname": container.hostname,
                     "nodeName": None, # Could be a specific node
                     "volumes": volumes,
                     "restartPolicy": restart_policy,
-                    "privileged": container.privileged,
                     "imagePullSecrets": secrets_spec,
                 }
             },


### PR DESCRIPTION
fix mapping to define priviliged mode in "securityContext" per container, as the per-pod flag is deprecated.