### PR TITLE
Wip/fix conflict periodic sync

### DIFF
--- a/zun/container/k8s/driver.py
+++ b/zun/container/k8s/driver.py
@@ -187,55 +187,73 @@ class K8sDriver(driver.ContainerDriver, driver.BaseDriver):
 
         utils.spawn_n(self._watch_pods, admin_context)
 
-    def _watch_pods(self, context):
-        def _do_watch():
-            watcher = watch.Watch()
+    def _process_pod_event(self, context, event):
+        """Map k8s pod events to update zun container info.
+
+        For each pod event in k8s, see if there's a matching zun container.
+        If so, we update the zun container to match current k8s status.
+
+        As an optimization, we watch only events from zun-managed pods, by 
+        using label selector `zun.openstack.org/type=container`.
+        """
+
+        pod = event["object"]
+        event_type = event["type"]
+        pod_name = f"{pod.metadata.namespace}/{pod.metadata.name}"
+        container_uuid = pod.metadata.labels[mapping.LABELS["uuid"]]
+
+        try:
+            container = objects.Container.get_by_uuid(context, container_uuid)
+            self._sync_container(container, pod, pod_event=event_type)
+            container.save()
+            LOG.info(f"Synced {container_uuid} to k8s state after {event_type} event")
+        except exception.ContainerNotFound:
+            # K8s pod claims to be zun managed, but not found in zun. May have been
+            # already deleted, it should be cleaned up during periodic sync.
+            LOG.info("Skipping update: k8s pod {} specifies missing zun container {}".format(pod_name, container_uuid))
+
+    def _do_watch(self, watcher: watch.Watch, context):
+        """Wrap a k8s watch in safe retry logic. See:
+        https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes
+        """
+        try:
+            # When you send a watch request, the API server responds with a stream of changes.
             for event in watcher.stream(
                 self.core_v1().list_pod_for_all_namespaces,
                 label_selector=f"{mapping.LABELS['type']}=container"):
-                pod = event["object"]
-                event_type = event["type"]
-                container_uuid = pod.metadata.labels[mapping.LABELS["uuid"]]
-                try:
-                    container = objects.Container.get_by_uuid(context, container_uuid)
-                    self._sync_container(container, pod, pod_event=event_type)
-                    container.save()
-                    LOG.info(
-                        f"Synced {container_uuid} to k8s state after {event_type} event")
-                except exception.ContainerNotFound:
-                    # Just skip this pod, it should be cleaned up on the periodic sync
-                    LOG.info(f"Skipping update on missing container '{container_uuid}'")
+                self._process_pod_event(context, event)
+        except client.ApiException as e:
+            if e.status == 410: # Resource too old, retry without resource version set
+                LOG.info("Got 410: resource too old for version {} retrying without resource_version...")
+                return self._do_watch(watcher=watcher, context=context)
+            else:
+                raise
+        except urllib3.exceptions.ProtocolError as e:
+            # avoid urrllib error when haproxy kills the long running connection
+            LOG.warn("Lost connection to the k8s API server. Reconnecting... %s", e)
 
-        backoff, max_backoff = 0.0, 128.0
-        def _get_backoff(current, maximum):
-            return min(max(current * 2, 1.0), maximum)
 
+    def _watch_pods(self, context):
+        """Get all changes applying to k8s pods managed by zun.
+
+        This is executed in a separate eventlet thread, and should never return until the program exits.
+        """
+
+        watcher = watch.Watch()
+
+        # main loop
         while True:
+            # the watch may time out or fail for a variety of reasons, we want to retry and keep it going.
+            # attempt to resume from latest resource version found. If this fails, _do_watch will retry without
             try:
-                if backoff:
-                    time.sleep(backoff)
-                _do_watch()
-            except client.ApiException as exc:
-                if exc.status == 410: # Resource too old, retry without resource version set
-                    LOG.info("Got 410: resource too old; retrying without resource_version...")
-                else:
-                    LOG.error(f"Unexpected K8s API error: {exc}")
-                    backoff = _get_backoff(backoff, max_backoff)
-            # Catches the following error:
-            # urllib3.exceptions.ProtocolError: ("Connection broken: InvalidChunkLength
-            except urllib3.exceptions.ProtocolError as exc:
-                LOG.warn("Lost connection to the k8s API server. Reconnecting... %s", exc)
-                backoff = _get_backoff(backoff, max_backoff)
-            except Exception as exc:
+                self._do_watch(watcher, context)
+                LOG.info("watch exited with no error. Retrying...")
+            except Exception as e:
                 # This indicates a business logic failure; our code is wrong. Keep
                 # the loop going but log the exception; possibly future watch events
                 # will not always trigger this error and we can keep the cluster from
                 # getting too far out of sync.
-                LOG.exception("Unexpected error watching pods")
-                backoff = _get_backoff(backoff, max_backoff)
-            else:
-                # no exception, drop backoff back down
-                backoff = 0
+                LOG.exception("Unexpected error watching pods: {}, restarting watch...", e)
 
     def periodic_sync(self, context):
         """Called by the compute manager periodically.
@@ -466,38 +484,29 @@ class K8sDriver(driver.ContainerDriver, driver.BaseDriver):
 
         return local_containers, non_existent_containers
 
-    def _get_local_containers(self, context, uuids):
-        host_containers = objects.Container.list_by_host(context, CONF.host)
-        uuids = list(set(uuids) | set([c.uuid for c in host_containers]))
-        containers = objects.Container.list(context,
-                                            filters={'uuid': uuids})
-        return containers
 
     def update_containers_states(self, context, containers, manager):
+        """Called by zun manager, periodically sync all containers states.
+
+        _watch_pods is already updating zun container state based on k8s state.
+        This method handles the remaining work of updating k8s state based on 
+        zun state, mostly cleaning up deployments for containers in a bad state.
+        """
         # TODO(jason): sync security group net policies (?)
 
-        local_containers, non_existent_containers = self.list(context)
+        for container in containers:
 
-        pod_map = {
-            pod.metadata.labels[mapping.LABELS["uuid"]]: pod
-            for pod in self.core_v1().list_pod_for_all_namespaces(
-                label_selector=f"{mapping.LABELS['type']}=container"
-            ).items
-        }
-
-        for container in local_containers:
             if container.task_state is not None:
                 # Container is in the middle of an operation; let it finish (the watcher
                 # should be handling updates for it).
                 continue
-            pod = pod_map.get(container.uuid)
-            self._sync_container(container, pod)
-            container.save(context)
 
-        for container in non_existent_containers:
-            if container.host == CONF.host:
-                container.status = consts.DELETED
-                container.save(context)
+            if container.host == CONF.host and container.status!=consts.DELETED:
+                if not self._pod_for_container(context, container):
+                    LOG.info("zun manager requests sync to delete container {}".format(container))
+                    LOG.warning("DRY RUN: couldn't find k8s pod for container {} during sync, deleting!.".format(container.uuid))
+                    # container.status = consts.DELETED
+                    # container.save(context)
 
     def show(self, context, container):
         """Show the details of a container."""

--- a/zun/container/k8s/driver.py
+++ b/zun/container/k8s/driver.py
@@ -484,6 +484,16 @@ class K8sDriver(driver.ContainerDriver, driver.BaseDriver):
 
         return local_containers, non_existent_containers
 
+    def _deployment_map(self):
+        """
+        Fetch all deployments and return map of zun container uuid -> deployment id.
+        """
+        deployment_list = self.apps_v1().list_deployment_for_all_namespaces(
+            label_selector=mapping.LABELS["uuid"])
+        return {
+            d.metadata.labels[mapping.LABELS["uuid"]]: d
+            for d in deployment_list.items
+        }
 
     def update_containers_states(self, context, containers, manager):
         """Called by zun manager, periodically sync all containers states.
@@ -494,23 +504,34 @@ class K8sDriver(driver.ContainerDriver, driver.BaseDriver):
         """
         # TODO(jason): sync security group net policies (?)
 
+        # Fetch updated deployments once per sync.
+        deployment_map = self._deployment_map()
+        
         for container in containers:
+            
+            deployment = deployment_map.get(container.uuid)
 
+            if container.host != CONF.host:
+                # Only act on containers we're responsible for
+                continue
+            
             if container.task_state is not None:
-                # Container is in the middle of an operation; let it finish (the watcher
-                # should be handling updates for it).
+                # Container is in the middle of an operation; let it finish
+                #  (the watcher should be handling updates for it).
                 continue
-
-            if container.host == CONF.host and container.status==consts.CREATING:
-                LOG.info("Skipping deletion check for container {}, still CREATING".format(container))
+            
+            if container.status==consts.DELETED:
+                # container is already deleted, leave the item around for reference.
                 continue
-
-            if container.host == CONF.host and container.status!=consts.DELETED:
-                if not self._pod_for_container(context, container):
-                    
-                    LOG.warning("Pod not found during sync, conflicting with zun cached state. Deleting zun container {}".format(container.uuid))
-                    container.status = consts.DELETED
-                    container.save(context)
+            
+            if container.status==consts.CREATING:
+                # container is still creating, we'll wait until that finishes
+                continue
+            
+            if not deployment:
+                LOG.warning("Deleting orphaned container; During sync, deployment not found for zun container {}".format(container.uuid))
+                container.status = consts.DELETED
+                container.save(context)
 
     def show(self, context, container):
         """Show the details of a container."""

--- a/zun/container/k8s/driver.py
+++ b/zun/container/k8s/driver.py
@@ -501,10 +501,14 @@ class K8sDriver(driver.ContainerDriver, driver.BaseDriver):
                 # should be handling updates for it).
                 continue
 
+            if container.host == CONF.host and container.status==consts.CREATING:
+                LOG.info("Skipping deletion check for container {}, still CREATING".format(container))
+                continue
+
             if container.host == CONF.host and container.status!=consts.DELETED:
                 if not self._pod_for_container(context, container):
-                    LOG.info("zun manager requests sync to delete container {}".format(container))
-                    LOG.warning("DRY RUN: couldn't find k8s pod for container {} during sync, deleting!.".format(container.uuid))
+                    
+                    LOG.warning("Pod not found during sync, conflicting with zun cached state. Deleting zun container {}".format(container.uuid))
                     container.status = consts.DELETED
                     container.save(context)
 

--- a/zun/container/k8s/driver.py
+++ b/zun/container/k8s/driver.py
@@ -505,8 +505,8 @@ class K8sDriver(driver.ContainerDriver, driver.BaseDriver):
                 if not self._pod_for_container(context, container):
                     LOG.info("zun manager requests sync to delete container {}".format(container))
                     LOG.warning("DRY RUN: couldn't find k8s pod for container {} during sync, deleting!.".format(container.uuid))
-                    # container.status = consts.DELETED
-                    # container.save(context)
+                    container.status = consts.DELETED
+                    container.save(context)
 
     def show(self, context, container):
         """Show the details of a container."""

--- a/zun/tests/unit/container/kubernetes/test_k8s_driver.py
+++ b/zun/tests/unit/container/kubernetes/test_k8s_driver.py
@@ -238,13 +238,24 @@ class TestK8sDriver(base.DriverTestCase):
             network=network,
         )
 
-    def test_update_containers_states_deletes_missing_running_container(self):
-        """
-        Test case for issue where zun periodic sync and k8s watch-based sync conflict.
-        The intent is that if a container is "missing" on the k8s side, the zun side
-        will be marked as deleted to clean it up.
-        """
+
+class TestUpdateContainersStates(TestK8sDriver):
+
+    def setUp(self):
+        super().setUp()
+
+        # Set "host" so we act as a specific service, used for syncronization checks.
         self.config(host="test-host")
+
+
+    def test_update_states_deletes_when_deployment_missing(self):
+        """
+        When a k8s zun container IS present, and a k8s deployment is NOT
+        Then assume there was a deletion in the background, and delete the zun
+        container.
+
+        This is most often triggered by blazar lease end.
+        """
 
         container = mock.MagicMock(
             spec_set=ZunContainer,
@@ -254,10 +265,9 @@ class TestK8sDriver(base.DriverTestCase):
             task_state=None,
         )
 
-        with mock.patch.object(self.driver, "_pod_for_container", return_value=None) as mock_pod:
-            #_pod_for_container returns none -> container present in zun, missing on k8s side
+        with mock.patch.object(self.driver, "_deployment_map", return_value={}) as mock_deployment:
             self.driver.update_containers_states(self.context, [container], mock.Mock())
-            mock_pod.assert_called_once_with(self.context, container)
+            mock_deployment.assert_called_once()
 
 
         self.assertEqual(consts.DELETED, container.status)
@@ -282,8 +292,9 @@ class TestK8sDriver(base.DriverTestCase):
             task_state=None,
         )
 
-        with mock.patch.object(self.driver, "_pod_for_container", return_value=None):
+        with mock.patch.object(self.driver, "_deployment_map", return_value={}) as mock_deployment:
             self.driver.update_containers_states(self.context, [container], mock.Mock())
+            mock_deployment.assert_called_once()
 
         self.assertEqual(consts.CREATING, container.status)
         container.save.assert_not_called()
@@ -304,9 +315,12 @@ class TestK8sDriver(base.DriverTestCase):
             task_state=None,
         )
 
-        with mock.patch.object(self.driver, "_pod_for_container", return_value=None) as mock_pod:
-            self.driver.update_containers_states(self.context, [container], mock.Mock())
+        deployments = {container.uuid: mock.MagicMock()}
 
-        mock_pod.assert_called_once_with(self.context, container)
+
+        with mock.patch.object(self.driver, "_deployment_map", return_value=deployments) as mock_deployment:
+            self.driver.update_containers_states(self.context, [container], mock.Mock())
+            mock_deployment.assert_called_once()
+
         self.assertEqual(consts.STOPPED, container.status)
         container.save.assert_not_called()

--- a/zun/tests/unit/container/kubernetes/test_k8s_driver.py
+++ b/zun/tests/unit/container/kubernetes/test_k8s_driver.py
@@ -38,6 +38,7 @@ class TestK8sDriver(base.DriverTestCase):
             self.driver.net_v1, "create_namespaced_network_policy"
         ).start()
 
+class TestK8sDriverActions(TestK8sDriver):
     def test_create(self):
         """Test container create method.
 

--- a/zun/tests/unit/container/kubernetes/test_k8s_driver.py
+++ b/zun/tests/unit/container/kubernetes/test_k8s_driver.py
@@ -5,6 +5,8 @@ from zun.container.k8s.driver import config as k8s_config
 from zun.container.k8s.network import K8sNetwork as zun_k8s_network
 from zun.objects.container import Container as ZunContainer
 from zun.tests.unit.container import base
+from zun.conf import CONF
+from zun.common import consts
 
 FAKE_PROJECT_ID = "aaaa-bbb-ccc-ddd"
 
@@ -235,3 +237,53 @@ class TestK8sDriver(base.DriverTestCase):
             self.driver.inspect_network,
             network=network,
         )
+
+    def test_update_containers_states_deletes_missing_running_container(self):
+        """
+        Test case for issue where zun periodic sync and k8s watch-based sync conflict.
+        The intent is that if a container is "missing" on the k8s side, the zun side
+        will be marked as deleted to clean it up.
+        """
+        self.config(host="test-host")
+
+        container = mock.MagicMock(
+            spec_set=ZunContainer,
+            uuid="11111111-1111-1111-1111-111111111111",
+            host=CONF.host,
+            status=consts.RUNNING,
+            task_state=None,
+        )
+
+        with mock.patch.object(self.driver, "_pod_for_container", return_value=None) as mock_pod:
+            #_pod_for_container returns none -> container present in zun, missing on k8s side
+            self.driver.update_containers_states(self.context, [container], mock.Mock())
+            mock_pod.assert_called_once_with(self.context, container)
+
+
+        self.assertEqual(consts.DELETED, container.status)
+        container.save.assert_called_once_with(self.context)
+
+    def test_update_containers_states_does_not_delete_creating_container(self):
+        """
+        Test case for issue where zun periodic sync and k8s watch-based sync conflict.
+        Similar to test_update_containers_states_deletes_missing_running_container.
+
+        The intent here is that if a container is "creating", e.g. on the k8s
+        side, the deployment exists, but the pod does not yet exist, we prevent
+        zun from acting on the "missing" container.
+        """
+        self.config(host="test-host")
+
+        container = mock.MagicMock(
+            spec_set=ZunContainer,
+            uuid="22222222-2222-2222-2222-222222222222",
+            host=CONF.host,
+            status=consts.CREATING,
+            task_state=None,
+        )
+
+        with mock.patch.object(self.driver, "_pod_for_container", return_value=None):
+            self.driver.update_containers_states(self.context, [container], mock.Mock())
+
+        self.assertEqual(consts.CREATING, container.status)
+        container.save.assert_not_called()

--- a/zun/tests/unit/container/kubernetes/test_k8s_driver.py
+++ b/zun/tests/unit/container/kubernetes/test_k8s_driver.py
@@ -287,3 +287,26 @@ class TestK8sDriver(base.DriverTestCase):
 
         self.assertEqual(consts.CREATING, container.status)
         container.save.assert_not_called()
+
+    def test_update_containers_states_does_not_delete_stopped_container_without_pod(self):
+        """
+        For a "stopped" zun container, we expect a deployment to be present with scale=0.
+        This means that there may be no matching "pod", but there WILL be a matching
+        deployment.
+        """
+        self.config(host="test-host")
+
+        container = mock.MagicMock(
+            spec_set=ZunContainer,
+            uuid="33333333-3333-3333-3333-333333333333",
+            host=CONF.host,
+            status=consts.STOPPED,
+            task_state=None,
+        )
+
+        with mock.patch.object(self.driver, "_pod_for_container", return_value=None) as mock_pod:
+            self.driver.update_containers_states(self.context, [container], mock.Mock())
+
+        mock_pod.assert_called_once_with(self.context, container)
+        self.assertEqual(consts.STOPPED, container.status)
+        container.save.assert_not_called()

--- a/zun/tests/unit/container/kubernetes/test_k8s_driver.py
+++ b/zun/tests/unit/container/kubernetes/test_k8s_driver.py
@@ -249,7 +249,7 @@ class TestUpdateContainersStates(TestK8sDriver):
         self.config(host="test-host")
 
 
-    def test_update_states_deletes_when_deployment_missing(self):
+    def test_deletes_when_deployment_missing(self):
         """
         When a k8s zun container IS present, and a k8s deployment is NOT
         Then assume there was a deletion in the background, and delete the zun
@@ -274,14 +274,9 @@ class TestUpdateContainersStates(TestK8sDriver):
         self.assertEqual(consts.DELETED, container.status)
         container.save.assert_called_once_with(self.context)
 
-    def test_update_containers_states_does_not_delete_creating_container(self):
+    def test_creating_not_deleted_when_deployment_missing(self):
         """
-        Test case for issue where zun periodic sync and k8s watch-based sync conflict.
-        Similar to test_update_containers_states_deletes_missing_running_container.
-
-        The intent here is that if a container is "creating", e.g. on the k8s
-        side, the deployment exists, but the pod does not yet exist, we prevent
-        zun from acting on the "missing" container.
+        Skip deletion if container still "creating", deployment might not be made yet.
         """
         self.config(host="test-host")
 
@@ -300,7 +295,7 @@ class TestUpdateContainersStates(TestK8sDriver):
         self.assertEqual(consts.CREATING, container.status)
         container.save.assert_not_called()
 
-    def test_update_containers_states_does_not_delete_stopped_container_without_pod(self):
+    def test_stopped_not_deleted_when_deployment_present(self):
         """
         For a "stopped" zun container, we expect a deployment to be present with scale=0.
         This means that there may be no matching "pod", but there WILL be a matching
@@ -324,4 +319,20 @@ class TestUpdateContainersStates(TestK8sDriver):
             mock_deployment.assert_called_once()
 
         self.assertEqual(consts.STOPPED, container.status)
+        container.save.assert_not_called()
+
+    def test_skips_when_task_state_set(self):
+        """Ensure we don't delete if task_state != none, k8s still in progress."""
+        container = mock.MagicMock(
+            spec_set=ZunContainer,
+            uuid="44444444-4444-4444-4444-444444444444",
+            host=CONF.host,
+            status=consts.RUNNING,
+            task_state=consts.CONTAINER_CREATING,
+        )
+
+        with mock.patch.object(self.driver, "_deployment_map", return_value={}):
+            self.driver.update_containers_states(self.context, [container], mock.Mock())
+
+        self.assertEqual(consts.RUNNING, container.status)
         container.save.assert_not_called()


### PR DESCRIPTION
We have both _watch_pods and update_containers_states making changes
_watch_pods is watching k8s for changes, and updates zun to match

update_containers_states is triggered periodically by zun compute
manager, and updates remaining things not handled by _watch_pods.

Main issues to answer:
1. update_containers_states deletes containers too agressively, causing issues during launch
1. update_containers_states will sometimes race to delete containers, raising DB errors during concurrent operations
1. not clear which method should handle "orphaned" pods, e.g. those present in k8s, but missing from zun.
1. some unclear cases when container present in zun, but state in k8s is transitional.

just making update_containers_states a noop seems to fix launches, but probably leaves orphaned resources!!