### PR TITLE
return status information from image pull errors

### DIFF
--- a/zun/container/k8s/driver.py
+++ b/zun/container/k8s/driver.py
@@ -109,6 +109,25 @@ def _format_status_detail(status_detail):
 
     return result
 
+
+_TERMINAL_IMAGE_PULL_REASONS = (
+    "ErrImagePull",
+    "InvalidImageName",
+)
+
+
+def _image_pull_error_message(waiting_message, image_ref):
+    hint = (
+        "Image pull failed. Verify image name/tag and registry access. "
+        "Small typos matter (for example '_' vs '-')."
+    )
+    if image_ref:
+        hint = f"{hint} image='{image_ref}'."
+    if waiting_message:
+        return f"{waiting_message} {hint}"
+    return hint
+
+
 def _pod_ips(pod):
     if not pod.status.pod_i_ps:
         return []
@@ -388,8 +407,21 @@ class K8sDriver(driver.ContainerDriver, driver.BaseDriver):
                 schedule_condition.reason == "Unschedulable"):
                 fail_due_to_condition(schedule_condition)
                 return
-            else:
-                transition_status(consts.CREATING)
+
+            # Handle image pull failures
+            statuses = pod_status.container_statuses or []
+            waiting = statuses[0].state.waiting if statuses and statuses[0].state else None
+            if waiting and waiting.reason in _TERMINAL_IMAGE_PULL_REASONS:
+                containers = pod.spec.containers if pod.spec else []
+                image_ref = containers[0].image if containers else None
+                container.status = consts.ERROR
+                container.task_state = None     # sync logic checks for this
+                container.status_detail = _format_status_detail(waiting.reason)
+                container.status_reason = _image_pull_error_message(
+                    waiting.message, image_ref)
+                return
+
+            transition_status(consts.CREATING)
         elif pod_status.phase == "Running":
             # The pod has been created. The container under the pod may however still
             # be having trouble starting.

--- a/zun/container/k8s/driver.py
+++ b/zun/container/k8s/driver.py
@@ -117,17 +117,6 @@ _IMAGE_PULL_STATUSES = (
 )
 
 
-def _image_pull_error_message(waiting_message, image_ref):
-    hint = (
-        "Image pull failed. Verify image name/tag and registry access. "
-        "Small typos matter (for example '_' vs '-')."
-    )
-    if image_ref:
-        hint = f"{hint} image='{image_ref}'."
-    if waiting_message:
-        return f"{waiting_message} {hint}"
-    return hint
-
 
 def _pod_ips(pod):
     if not pod.status.pod_i_ps:
@@ -418,8 +407,7 @@ class K8sDriver(driver.ContainerDriver, driver.BaseDriver):
                 image_ref = containers[0].image if containers else None
                 # update status detail and reason while we try.
                 container.status_detail = _format_status_detail(waiting.reason)
-                container.status_reason = _image_pull_error_message(
-                    waiting.message, image_ref)
+                container.status_reason = waiting.message
                 return
 
             transition_status(consts.CREATING)

--- a/zun/container/k8s/driver.py
+++ b/zun/container/k8s/driver.py
@@ -110,9 +110,10 @@ def _format_status_detail(status_detail):
     return result
 
 
-_TERMINAL_IMAGE_PULL_REASONS = (
+_IMAGE_PULL_STATUSES = (
     "ErrImagePull",
     "InvalidImageName",
+    "ImagePullBackOff"
 )
 
 
@@ -408,14 +409,14 @@ class K8sDriver(driver.ContainerDriver, driver.BaseDriver):
                 fail_due_to_condition(schedule_condition)
                 return
 
-            # Handle image pull failures
+            # Handle image pull failures. These aren't always terminal, so don't 
+            # set container.status = consts.ERROR
             statuses = pod_status.container_statuses or []
             waiting = statuses[0].state.waiting if statuses and statuses[0].state else None
-            if waiting and waiting.reason in _TERMINAL_IMAGE_PULL_REASONS:
+            if waiting and waiting.reason in _IMAGE_PULL_STATUSES:
                 containers = pod.spec.containers if pod.spec else []
                 image_ref = containers[0].image if containers else None
-                container.status = consts.ERROR
-                container.task_state = None     # sync logic checks for this
+                # update status detail and reason while we try.
                 container.status_detail = _format_status_detail(waiting.reason)
                 container.status_reason = _image_pull_error_message(
                     waiting.message, image_ref)

--- a/zun/tests/unit/container/kubernetes/test_k8s_driver.py
+++ b/zun/tests/unit/container/kubernetes/test_k8s_driver.py
@@ -336,3 +336,66 @@ class TestUpdateContainersStates(TestK8sDriver):
 
         self.assertEqual(consts.RUNNING, container.status)
         container.save.assert_not_called()
+
+_TERMINAL_IMAGE_PULL_REASONS = (
+    "ErrImagePull",
+    "InvalidImageName",
+)
+
+class TestSyncContainerImagePullErrors(TestK8sDriver):
+
+    def setUp(self):
+        super().setUp()
+        self.driver.network_driver = mock.MagicMock()
+    
+
+    def _creating_container(self):
+        return mock.MagicMock(
+            spec_set=ZunContainer,
+            status=consts.CREATING,
+            task_state=consts.CONTAINER_CREATING,
+        )
+
+    def _pending_pod(self, waiting_reason, waiting_message, image_ref):
+        pod = mock.MagicMock()
+        pod.status = mock.MagicMock(
+            phase="Pending",
+            conditions=[mock.MagicMock(
+                type="PodScheduled",
+                status="True",
+                reason="Scheduled",
+                message="pod scheduled",
+            )],
+            container_statuses=[mock.MagicMock(
+                state=mock.MagicMock(waiting=mock.MagicMock(
+                    reason=waiting_reason,
+                    message=waiting_message,
+                )),
+                restart_count=0,
+            )],
+            reason=None,
+            message=None,
+        )
+        pod.spec = mock.MagicMock(
+            containers=[mock.MagicMock(image=image_ref)],
+        )
+        return pod
+
+    def test_pending_terminal_image_pull_reasons_fail_fast(self):
+        image_ref = "ghcr.io/chameleoncloud/edge_sensehat_image:latest"
+        for waiting_reason in _TERMINAL_IMAGE_PULL_REASONS:
+            with self.subTest(waiting_reason=waiting_reason):
+                container = self._creating_container()
+                pod = self._pending_pod(
+                    waiting_reason=waiting_reason,
+                    waiting_message="failed to resolve reference: not found",
+                    image_ref=image_ref,
+                )
+
+                self.driver._sync_container(container, pod)
+
+                self.assertEqual(consts.ERROR, container.status)
+                self.assertEqual(waiting_reason, container.status_detail)
+                self.assertIn("failed to resolve reference", container.status_reason)
+                self.assertIn(image_ref, container.status_reason)
+                self.assertIsNone(container.task_state)

--- a/zun/tests/unit/container/kubernetes/test_k8s_driver.py
+++ b/zun/tests/unit/container/kubernetes/test_k8s_driver.py
@@ -382,6 +382,14 @@ class TestSyncContainerImagePullErrors(TestK8sDriver):
         return pod
 
     def test_pending_terminal_image_pull_reasons_fail_fast(self):
+        """This is actually complicated...
+
+        We can't set to error, because error implies a terminal case.
+        These image statuses are not necessarily terminal.
+
+        Instead, just set status reason and status detail, but leave in creating.
+        Separate logic should handle failing due to timeout or retries.
+        """
         image_ref = "ghcr.io/chameleoncloud/edge_sensehat_image:latest"
         for waiting_reason in _TERMINAL_IMAGE_PULL_REASONS:
             with self.subTest(waiting_reason=waiting_reason):
@@ -394,8 +402,8 @@ class TestSyncContainerImagePullErrors(TestK8sDriver):
 
                 self.driver._sync_container(container, pod)
 
-                self.assertEqual(consts.ERROR, container.status)
+                # Still creating, but has the status detail and reason
+                self.assertEqual(consts.CREATING, container.status)
                 self.assertEqual(waiting_reason, container.status_detail)
                 self.assertIn("failed to resolve reference", container.status_reason)
                 self.assertIn(image_ref, container.status_reason)
-                self.assertIsNone(container.task_state)

--- a/zun/tests/unit/container/kubernetes/test_k8s_driver.py
+++ b/zun/tests/unit/container/kubernetes/test_k8s_driver.py
@@ -337,17 +337,16 @@ class TestUpdateContainersStates(TestK8sDriver):
         self.assertEqual(consts.RUNNING, container.status)
         container.save.assert_not_called()
 
-_TERMINAL_IMAGE_PULL_REASONS = (
+_IMAGE_PULL_STATUSES = (
     "ErrImagePull",
     "InvalidImageName",
+    "ImagePullBackOff",
 )
 
 class TestSyncContainerImagePullErrors(TestK8sDriver):
-
     def setUp(self):
         super().setUp()
         self.driver.network_driver = mock.MagicMock()
-    
 
     def _creating_container(self):
         return mock.MagicMock(
@@ -360,19 +359,25 @@ class TestSyncContainerImagePullErrors(TestK8sDriver):
         pod = mock.MagicMock()
         pod.status = mock.MagicMock(
             phase="Pending",
-            conditions=[mock.MagicMock(
-                type="PodScheduled",
-                status="True",
-                reason="Scheduled",
-                message="pod scheduled",
-            )],
-            container_statuses=[mock.MagicMock(
-                state=mock.MagicMock(waiting=mock.MagicMock(
-                    reason=waiting_reason,
-                    message=waiting_message,
-                )),
-                restart_count=0,
-            )],
+            conditions=[
+                mock.MagicMock(
+                    type="PodScheduled",
+                    status="True",
+                    reason="Scheduled",
+                    message="pod scheduled",
+                )
+            ],
+            container_statuses=[
+                mock.MagicMock(
+                    state=mock.MagicMock(
+                        waiting=mock.MagicMock(
+                            reason=waiting_reason,
+                            message=waiting_message,
+                        )
+                    ),
+                    restart_count=0,
+                )
+            ],
             reason=None,
             message=None,
         )
@@ -391,7 +396,7 @@ class TestSyncContainerImagePullErrors(TestK8sDriver):
         Separate logic should handle failing due to timeout or retries.
         """
         image_ref = "ghcr.io/chameleoncloud/edge_sensehat_image:latest"
-        for waiting_reason in _TERMINAL_IMAGE_PULL_REASONS:
+        for waiting_reason in _IMAGE_PULL_STATUSES:
             with self.subTest(waiting_reason=waiting_reason):
                 container = self._creating_container()
                 pod = self._pending_pod(
@@ -405,5 +410,4 @@ class TestSyncContainerImagePullErrors(TestK8sDriver):
                 # Still creating, but has the status detail and reason
                 self.assertEqual(consts.CREATING, container.status)
                 self.assertEqual(waiting_reason, container.status_detail)
-                self.assertIn("failed to resolve reference", container.status_reason)
-                self.assertIn(image_ref, container.status_reason)
+                self.assertEqual("failed to resolve reference: not found", container.status_reason)


### PR DESCRIPTION
Kubernetes makes information available about "conditions" affecting containers. We should use this to let users know whats taking so long.

The easiest first step is to expose info from image pull errors, as they're easy to trigger with typos.

As these are not necessarily terminal cases, we don't set ERROR, but do set status detail and status reason so clients can decide.