### PR TITLE
support interactive container exec on kubernetes backend

### DIFF
--- a/releasenotes/notes/exec-instance-single-use-2a3b4c5d6e7f8091.yaml
+++ b/releasenotes/notes/exec-instance-single-use-2a3b4c5d6e7f8091.yaml
@@ -1,0 +1,8 @@
+---
+security:
+  - |
+    Interactive exec tokens are now single-use. When a client connects to the
+    websocket proxy for an exec, the ``ExecInstance`` row is deleted under a
+    row lock before the command is started, so the same token cannot be
+    replayed to invoke the command more than once, and concurrent workers
+    cannot both claim the same exec.

--- a/releasenotes/notes/fix-wsproxy-eof-flush-0a1b2c3d4e5f6071.yaml
+++ b/releasenotes/notes/fix-wsproxy-eof-flush-0a1b2c3d4e5f6071.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug in the websocket proxy where the tail of an interactive
+    session's output could be dropped when the target connection closed.
+    Output still queued for the client is now flushed (honoring backpressure,
+    bounded by a timeout so a dead client cannot hang the worker) before the
+    proxy closes the connection.

--- a/releasenotes/notes/k8s-interactive-exec-3a4b5c6d7e8f90a1.yaml
+++ b/releasenotes/notes/k8s-interactive-exec-3a4b5c6d7e8f90a1.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Added interactive shell ``exec`` support for the Kubernetes container
+    driver. A client can now attach an interactive terminal to a command in a
+    Kubernetes-backed container through the websocket proxy, which relays the
+    Kubernetes remotecommand protocol.
+issues:
+  - |
+    Terminal resize is not yet supported for interactive ``exec`` on the
+    Kubernetes driver; the session uses the terminal size at attach time.

--- a/releasenotes/notes/widen-exec-instance-url-1a2b3c4d5e6f7081.yaml
+++ b/releasenotes/notes/widen-exec-instance-url-1a2b3c4d5e6f7081.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    The ``exec_instance.url`` column has been widened from ``VARCHAR(255)`` to
+    ``TEXT`` to accommodate longer exec target URLs (some backends encode the
+    exec command into the URL). Run ``zun-db-manage upgrade`` to apply the
+    schema migration.

--- a/zun/compute/manager.py
+++ b/zun/compute/manager.py
@@ -847,7 +847,8 @@ class Manager(periodic_task.PeriodicTasks):
                         "token": None}
             else:
                 token = uuidutils.generate_uuid()
-                url = CONF.docker.docker_remote_api_url
+                url = self.driver.get_exec_url(context, container, exec_id,
+                                               command, interactive)
                 exec_instace = objects.ExecInstance(
                     context, container_id=container.id, exec_id=exec_id,
                     url=url, token=token)

--- a/zun/compute/manager.py
+++ b/zun/compute/manager.py
@@ -837,7 +837,7 @@ class Manager(periodic_task.PeriodicTasks):
         try:
             # NOTE(hongbin): capsule shouldn't reach here
             exec_id = self.driver.execute_create(context, container, command,
-                                                 interactive)
+                                                 run=run, interactive=interactive)
             if run:
                 # NOTE(hongbin): capsule shouldn't reach here
                 output, exit_code = self.driver.execute_run(exec_id, command)

--- a/zun/container/docker/driver.py
+++ b/zun/container/docker/driver.py
@@ -855,7 +855,7 @@ class DockerDriver(driver.BaseDriver, driver.ContainerDriver,
 
     @check_container_id
     @wrap_docker_error
-    def execute_create(self, context, container, command, interactive=False):
+    def execute_create(self, context, container, command, run=True, interactive=False):
         stdin = True if interactive else False
         tty = True if interactive else False
         with docker_utils.docker_client() as docker:

--- a/zun/container/docker/driver.py
+++ b/zun/container/docker/driver.py
@@ -887,6 +887,9 @@ class DockerDriver(driver.BaseDriver, driver.ContainerDriver,
                         "no such exec instance: %s") % str(api_error))
                 raise
 
+    def get_exec_url(self, context, container, exec_id, command, interactive):
+        return CONF.docker.docker_remote_api_url
+
     @check_container_id
     @wrap_docker_error
     def kill(self, context, container, signal=None):

--- a/zun/container/driver.py
+++ b/zun/container/driver.py
@@ -406,6 +406,10 @@ class ContainerDriver(object):
         """Resizes the tty session used by the exec."""
         raise NotImplementedError()
 
+    def get_exec_url(self, context, container, exec_id, command, interactive):
+        """Get the target url the websocket proxy connects to for an exec."""
+        raise NotImplementedError()
+
     def kill(self, context, container, signal):
         """Kill a container with specified signal."""
         raise NotImplementedError()

--- a/zun/container/driver.py
+++ b/zun/container/driver.py
@@ -394,8 +394,13 @@ class ContainerDriver(object):
         """Show logs of a container."""
         raise NotImplementedError()
 
-    def execute_create(self, context, container, command, **kwargs):
-        """Create an execute instance for running a command."""
+    def execute_create(self, context, container, command, run=True, interactive=False):
+        """Create an execute instance for running a command.
+
+        When run is True, execute now and return a result that execute_run can
+        return directly. When run is False, return an opaque handle to store on
+        the ExecInstance and trigger later via the websocket proxy (get_exec_url).
+        """
         raise NotImplementedError()
 
     def execute_run(self, exec_id, command):

--- a/zun/container/k8s/driver.py
+++ b/zun/container/k8s/driver.py
@@ -38,12 +38,10 @@ from zun.common.docker_image import reference as docker_image
 from zun.container import driver
 from zun.container.k8s import exception as k8s_exc
 from zun.container.k8s import host, mapping, network, volume
+from zun.websocket.k8s_remotecommand import Channel
 
 CONF = zun.conf.CONF
 LOG = logging.getLogger(__name__)
-
-STDOUT_CHANNEL = 1
-STDERR_CHANNEL = 2
 
 # A fake "network id" for when we want to keep track of container
 # addresses but the driver is not configured to integrate w/ Neutron.
@@ -97,7 +95,7 @@ def _select_update(self, timeout=0):
                 channel = ord(data[0])
                 data = data[1:]
                 if data:
-                    if channel in (STDOUT_CHANNEL, STDERR_CHANNEL):
+                    if channel in (Channel.STDOUT, Channel.STDERR):
                         # keeping all messages in the order they received
                         # for non-blocking call.
                         self._all.write(data)
@@ -191,9 +189,9 @@ class WSFileManager:
                             channel = data[0]
                             data = data[1:]
                             if data:
-                                if channel == STDOUT_CHANNEL:
+                                if channel == Channel.STDOUT:
                                     stdout_bytes = data
-                                elif channel == STDERR_CHANNEL:
+                                elif channel == Channel.STDERR:
                                     stderr_bytes = data
         return stdout_bytes, stderr_bytes, not self.ws_client._connected
 

--- a/zun/container/k8s/driver.py
+++ b/zun/container/k8s/driver.py
@@ -18,6 +18,7 @@ import shlex
 import time
 from collections import defaultdict
 from pathlib import Path
+from urllib.parse import urlencode
 
 from kubernetes import client, config, watch
 from kubernetes.stream import stream
@@ -692,8 +693,18 @@ class K8sDriver(driver.ContainerDriver, driver.BaseDriver):
 
         return ws_client
 
-    def execute_create(self, context, container, command, interactive=None, **kwargs):
+    def execute_create(self, context, container, command, run=True, interactive=False):
         """Create an execute instance for running a command."""
+
+        if not run:
+            # The command executes when a client connects to the websocket.
+            # Return a primary key for the exec instance stored in the DB.
+            # it will be looked up and matched on exec_id, container_id, and
+            # token.
+            # 64 character hex chosen to match docker exec id, since api validates.
+            return os.urandom(32).hex()
+
+        # run=True: execute synchronously and return the result for execute_run.
         ws_client = self._connect_pod_exec(context, container, command, stdin=False)
         ws_client.run_forever(timeout=CONF.k8s.execute_timeout)
 
@@ -720,14 +731,63 @@ class K8sDriver(driver.ContainerDriver, driver.BaseDriver):
 
     def execute_resize(self, exec_id, height, width):
         """Resizes the tty session used by the exec."""
-        # Write to the websocket open for the exec
-        raise NotImplementedError()
+        # k8s tty resize is sent in-band on the exec websocket, which the
+        # proxy holds (not this process); nothing to do here.
+        # TODO: handle this somehow.
+        LOG.info("Ignoring exec resize for %s; handled by websocket proxy",
+                 exec_id)
 
     def kill(self, context, container, signal):
         """Kill a container with specified signal."""
         LOG.info("Killing container %s with signal %s", container.uuid, signal)
         LOG.warning("Killing a container with signal %s is not supported, stopping instead", signal)
         self.stop(context=context, container=container, timeout=None)
+
+    def _exec_url_for_command(self, context, container, command, interactive):
+        """Implement k8s remotecommand exec.
+        https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#get-connect-exec-pod-v1-core
+        """
+
+        # look up pod from container
+        pod = self._pod_for_container(context, container)
+        if not pod:
+            raise exception.ContainerNotFound()
+
+        name = pod.metadata.name
+        namespace = pod.metadata.namespace
+
+        # k8s wants one command= param per argv element.
+        params = []
+        command_array = shlex.split(command)
+        for cmd in command_array:
+            params.append(("command", cmd))
+
+        # if interactive, allocate tty and plumb stdin
+        # when tty set, stderr and stdout combined
+        if interactive:
+            params.append(("tty", "true"))
+            params.append(("stdin", "true"))
+            params.append(("stdout", "true"))
+            params.append(("stderr", "false"))
+        else:
+            params.append(("tty", "false"))
+            params.append(("stdin", "false"))
+            params.append(("stdout", "true"))
+            params.append(("stderr", "true"))
+
+        query = urlencode(params)
+
+        # websocket url for api host
+        host = self.core_v1().api_client.configuration.host.replace(
+            "https:", "wss:")
+
+        return f"{host}/api/v1/namespaces/{namespace}/pods/{name}/exec?{query}"
+
+    def get_exec_url(self, context, container, exec_id, command, interactive):
+        # exec_id is the opaque handle from execute_create; for k8s the command
+        # is encoded in the url itself, it isn't needed here.
+        return self._exec_url_for_command(
+            context, container, command, interactive)
 
     def get_websocket_url(self, context, container):
         """Get websocket url of a container."""

--- a/zun/db/api.py
+++ b/zun/db/api.py
@@ -1080,6 +1080,18 @@ def list_exec_instances(context, filters=None, limit=None, marker=None,
         context, filters, limit, marker, sort_key, sort_dir)
 
 
+@profiler.trace("db")
+def destroy_exec_instance(context, exec_instance_id):
+    """Destroy an exec instance.
+
+    :param context: The security context
+    :param exec_instance_id: The id of the exec instance to destroy.
+    :returns: the number of rows deleted (1 if deleted, 0 if already gone).
+    """
+    return _get_dbdriver_instance().destroy_exec_instance(
+        context, exec_instance_id)
+
+
 @profiler.trace('db')
 def count_usage(context, container_type, project_id, flag):
     return _get_dbdriver_instance().count_usage(context, container_type,

--- a/zun/db/sqlalchemy/alembic/versions/b7e2c1a9d4f3_widen_exec_instance_url.py
+++ b/zun/db/sqlalchemy/alembic/versions/b7e2c1a9d4f3_widen_exec_instance_url.py
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""widen exec_instance url
+
+The k8s backend encodes the exec command into the target url which easily
+exceeds 255 characters. Store it as TEXT instead.
+
+Revision ID: b7e2c1a9d4f3
+Revises: f979327df44b
+Create Date: 2026-06-23 12:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b7e2c1a9d4f3'
+down_revision = 'f979327df44b'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('exec_instance', schema=None) as batch_op:
+        batch_op.alter_column('url',
+                              existing_type=sa.String(255),
+                              type_=sa.Text(),
+                              existing_nullable=True)

--- a/zun/db/sqlalchemy/api.py
+++ b/zun/db/sqlalchemy/api.py
@@ -1288,6 +1288,14 @@ class Connection(object):
                 exec_id=values['exec_id'])
         return exec_inst
 
+    def destroy_exec_instance(self, context, exec_instance_id):
+        # Returns number of rows deleted, 1 if this call did it,
+        # 0 if already deleted.
+        session = get_session()
+        with session.begin():
+            return model_query(models.ExecInstance, session=session) \
+                .filter_by(id=exec_instance_id).delete()
+
     def count_usage(self, context, container_type, project_id, flag):
         session = get_session()
         if flag == 'containers':

--- a/zun/db/sqlalchemy/models.py
+++ b/zun/db/sqlalchemy/models.py
@@ -247,7 +247,7 @@ class ExecInstance(Base):
                           nullable=False)
     exec_id = Column(String(255), nullable=False)
     token = Column(String(255), nullable=True)
-    url = Column(String(255), nullable=True)
+    url = Column(Text(), nullable=True)
     container = orm.relationship(
         Container,
         backref=orm.backref('exec_instances'),

--- a/zun/objects/exec_instance.py
+++ b/zun/objects/exec_instance.py
@@ -23,7 +23,8 @@ LOG = logging.getLogger(__name__)
 @base.ZunObjectRegistry.register
 class ExecInstance(base.ZunPersistentObject, base.ZunObject):
     # Version 1.0: Initial version
-    VERSION = '1.0'
+    # Version 1.1: Add destroy()
+    VERSION = '1.1'
 
     fields = {
         'id': fields.IntegerField(),
@@ -59,3 +60,9 @@ class ExecInstance(base.ZunPersistentObject, base.ZunObject):
         values = self.obj_get_changes()
         db_exec_inst = dbapi.create_exec_instance(context, values)
         self._from_db_object(self, db_exec_inst)
+
+    @base.remotable
+    def destroy(self, context=None):
+        deleted = dbapi.destroy_exec_instance(context, self.id)
+        self.obj_reset_changes()
+        return deleted

--- a/zun/tests/unit/compute/test_compute_manager.py
+++ b/zun/tests/unit/compute/test_compute_manager.py
@@ -1079,7 +1079,7 @@ class TestManager(base.TestCase):
         self.assertIsNone(result.get('exec_id'))
         self.assertIsNone(result.get('token'))
         mock_execute_create.assert_called_once_with(
-            self.context, container, 'fake_cmd', False)
+            self.context, container, 'fake_cmd', run=True, interactive=False)
         mock_execute_run.assert_called_once_with('fake_exec_id', 'fake_cmd')
 
     @mock.patch.object(ExecInstance, 'create')
@@ -1096,7 +1096,7 @@ class TestManager(base.TestCase):
         self.assertEqual('fake_exec_id', result.get('exec_id'))
         self.assertIsNotNone(result.get('token'))
         mock_execute_create.assert_called_once_with(
-            self.context, container, 'fake_cmd', True)
+            self.context, container, 'fake_cmd', run=False, interactive=True)
         mock_execute_run.assert_not_called()
 
     @mock.patch.object(fake_driver, 'execute_create')

--- a/zun/tests/unit/container/fake_driver.py
+++ b/zun/tests/unit/container/fake_driver.py
@@ -102,6 +102,9 @@ class FakeDriver(driver.BaseDriver, driver.ContainerDriver,
     def get_websocket_url(self, context, container):
         pass
 
+    def get_exec_url(self, context, container, exec_id, command, interactive):
+        return 'fake_exec_url'
+
     @check_container_id
     def resize(self, context, container, height, weight):
         pass

--- a/zun/tests/unit/container/kubernetes/test_k8s_driver.py
+++ b/zun/tests/unit/container/kubernetes/test_k8s_driver.py
@@ -141,14 +141,35 @@ class TestK8sDriverActions(TestK8sDriver):
             mock_container,
         )
 
+    def test_execute_create_deferred_returns_handle(self):
+        # run=False must not execute now; it returns an opaque handle for the
+        # ExecInstance, and the command runs when a client attaches.
+        with mock.patch.object(self.driver, "_connect_pod_exec") as mock_conn:
+            handle = self.driver.execute_create(
+                self.context, mock.MagicMock(), "ls", run=False)
+        self.assertIsInstance(handle, str)
+        mock_conn.assert_not_called()
+
+    def test_execute_create_run_executes_synchronously(self):
+        # run=True connects, runs to completion, and returns the result that
+        # execute_run hands back.
+        ws_client = mock.MagicMock()
+        ws_client.returncode = 0
+        ws_client.read_all.return_value = "hello"
+        with mock.patch.object(self.driver, "_connect_pod_exec",
+                               return_value=ws_client) as mock_conn:
+            result = self.driver.execute_create(
+                self.context, mock.MagicMock(), "ls", run=True)
+        mock_conn.assert_called_once()
+        ws_client.run_forever.assert_called_once()
+        self.assertEqual({"output": "hello", "exit_code": 0}, result)
+
     def test_execute_resize(self):
-        self.assertRaises(
-            NotImplementedError,
-            self.driver.execute_resize,
-            exec_id=None,
-            height=None,
-            width=None,
-        )
+        # k8s tty resize is handled in-band by the websocket proxy; the driver
+        # method is intentionally a no-op.
+        self.assertIsNone(
+            self.driver.execute_resize(
+                exec_id=None, height=None, width=None))
 
     def test_resize(self):
         mock_container = mock.MagicMock()

--- a/zun/tests/unit/db/test_exec_instance.py
+++ b/zun/tests/unit/db/test_exec_instance.py
@@ -87,3 +87,14 @@ class DbExecInstanceTestCase(base.DbTestCase):
         res = dbapi.list_exec_instances(
             self.context, filters={'container_id': 777})
         self.assertEqual([], [r.id for r in res])
+
+    def test_destroy_exec_instance(self):
+        exec_inst = utils.create_test_exec_instance(context=self.context)
+        deleted = dbapi.destroy_exec_instance(self.context, exec_inst.id)
+        self.assertEqual(1, deleted)
+        res = dbapi.list_exec_instances(self.context)
+        self.assertEqual([], [r.id for r in res])
+
+        # doing it a second time should return 0 rows
+        second_deletion = dbapi.destroy_exec_instance(self.context, exec_inst.id)
+        self.assertEqual(0, second_deletion)

--- a/zun/tests/unit/objects/test_exec_instance.py
+++ b/zun/tests/unit/objects/test_exec_instance.py
@@ -50,3 +50,15 @@ class TestExecInstanceObject(base.DbTestCase):
             mock_create_exec_instance.assert_called_once_with(
                 self.context, self.fake_exec_inst)
             self.assertEqual(self.context, exec_inst._context)
+
+    def test_destroy(self):
+        with mock.patch.object(self.dbapi, 'destroy_exec_instance',
+                               autospec=True) as mock_destroy_exec_instance:
+            mock_destroy_exec_instance.return_value = 1
+            exec_inst = objects.ExecInstance(
+                self.context, **self.fake_exec_inst)
+            deleted = exec_inst.destroy(self.context)
+            mock_destroy_exec_instance.assert_called_once_with(
+                self.context, self.fake_exec_inst['id'])
+            self.assertEqual(1, deleted)
+            self.assertEqual(self.context, exec_inst._context)

--- a/zun/tests/unit/objects/test_objects.py
+++ b/zun/tests/unit/objects/test_objects.py
@@ -369,7 +369,7 @@ object_data = {
     'ContainerAction': '1.2-4ae05fe3d1576c211c2425e4db190ef2',
     'ContainerActionEvent': '1.0-2974d0a6f5d4821fd4e223a88c10181a',
     'ZunNetwork': '1.1-26e8d37a54e5fc905ede657744a221d9',
-    'ExecInstance': '1.0-59464e7b96db847c0abb1e96d3cec30a',
+    'ExecInstance': '1.1-3cb383dd00768e8fb09a14004ff4d621',
     'Registry': '1.0-9fddfae03f3ca052cc26c924642b9268',
     'RequestGroup': '1.0-5e08d68d0a63b729778340d608ec4eae',
 }

--- a/zun/tests/unit/websocket/test_k8s_remotecommand.py
+++ b/zun/tests/unit/websocket/test_k8s_remotecommand.py
@@ -1,0 +1,42 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from zun.tests import base
+from zun.websocket import k8s_remotecommand as rc
+
+
+class K8sRemoteCommandTestCase(base.TestCase):
+
+    def test_frame_from_client_prepends_stdin_channel(self):
+        self.assertEqual(b"\x00hello", rc.frame_from_client(b"hello"))
+
+    def test_frame_from_client_empty(self):
+        self.assertEqual(b"\x00", rc.frame_from_client(b""))
+
+    def test_payload_for_client_stdout(self):
+        self.assertEqual(b"out", rc.payload_for_client(b"\x01out"))
+
+    def test_payload_for_client_stderr(self):
+        self.assertEqual(b"err", rc.payload_for_client(b"\x02err"))
+
+    def test_payload_for_client_error_channel_dropped(self):
+        self.assertIsNone(rc.payload_for_client(b'\x03{"status":"Success"}'))
+
+    def test_payload_for_client_resize_channel_dropped(self):
+        self.assertIsNone(rc.payload_for_client(b"\x04stuff"))
+
+    def test_payload_for_client_empty_frame_dropped(self):
+        self.assertIsNone(rc.payload_for_client(b""))
+
+    def test_payload_for_client_channel_byte_only_dropped(self):
+        # stdout channel but no payload -> nothing to forward
+        self.assertIsNone(rc.payload_for_client(b"\x01"))

--- a/zun/tests/unit/websocket/test_websocketproxy.py
+++ b/zun/tests/unit/websocket/test_websocketproxy.py
@@ -1,0 +1,128 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from unittest import mock
+
+from zun.tests import base
+from zun.websocket import websocketproxy
+
+
+class FakeCClose(Exception):
+    """Stand-in for websockify's CClose so tests don't need the real server."""
+
+
+def _make_handler(cqueue=None, c_pend=False):
+    """Build a bare handler without running websockify's socket __init__.
+
+    _handle_ins_outs / _drain_cqueue_to_client live on the plain base class
+    and only touch instance attributes we set here, so we can exercise them
+    without a real socket.
+    """
+    handler = object.__new__(websocketproxy.ZunProxyRequestHandlerBase)
+    handler.cqueue = [] if cqueue is None else cqueue
+    handler.tqueue = []
+    handler.c_pend = c_pend
+    handler.framed = False
+    handler.request = mock.Mock(name="client_request")
+    handler.server = mock.Mock(target_host="host", target_port=1234)
+    handler.send_frames = mock.Mock(return_value=False)
+    handler.recv_frames = mock.Mock(return_value=([], False))
+    handler.msg = mock.Mock()
+    handler.CClose = FakeCClose
+    return handler
+
+
+class DrainCqueueTestCase(base.TestCase):
+
+    def test_flushes_queued_tail(self):
+        # The bug: queued output must be sent before close, not discarded.
+        handler = _make_handler(cqueue=[b"tail"])
+
+        handler._drain_cqueue_to_client()
+
+        handler.send_frames.assert_called_once_with([b"tail"])
+        self.assertEqual([], handler.cqueue)
+        self.assertFalse(handler.c_pend)
+
+    def test_nothing_queued_does_not_call_send(self):
+        handler = _make_handler(cqueue=[], c_pend=False)
+
+        handler._drain_cqueue_to_client()
+
+        handler.send_frames.assert_not_called()
+
+    @mock.patch.object(websocketproxy, "select")
+    def test_retries_on_backpressure_then_succeeds(self, mock_select):
+        # First send is backpressured (True), client then becomes writable,
+        # second send drains fully (False).
+        handler = _make_handler(cqueue=[b"a"])
+        handler.send_frames.side_effect = [True, False]
+        mock_select.select.return_value = ([], [handler.request], [])
+
+        handler._drain_cqueue_to_client()
+
+        self.assertEqual(2, handler.send_frames.call_count)
+        self.assertFalse(handler.c_pend)
+        mock_select.select.assert_called_once()
+
+    @mock.patch.object(websocketproxy, "time")
+    @mock.patch.object(websocketproxy, "select")
+    def test_dead_client_does_not_hang(self, mock_select, mock_time):
+        # send_frames never drains and the client never becomes writable;
+        # the loop must give up rather than spin forever.
+        handler = _make_handler(cqueue=[b"a"])
+        handler.send_frames.return_value = True
+        mock_time.time.return_value = 1000.0  # constant clock -> bounded loop
+        mock_select.select.return_value = ([], [], [])  # not writable
+
+        handler._drain_cqueue_to_client(timeout=2.0)
+
+        # One send attempt, one select that reports not-writable, then break.
+        handler.send_frames.assert_called_once()
+        mock_select.select.assert_called_once()
+        self.assertTrue(handler.c_pend)
+
+
+class HandleInsOutsEofTestCase(base.TestCase):
+
+    def _eof_handler(self, cqueue):
+        handler = _make_handler(cqueue=cqueue)
+        target = mock.Mock(name="target")
+        target.recv.return_value = b""  # EOF
+        return handler, target
+
+    def test_eof_flushes_then_closes(self):
+        handler, target = self._eof_handler(cqueue=[b"final"])
+
+        self.assertRaises(
+            FakeCClose,
+            handler._handle_ins_outs,
+            target, [target], [],
+        )
+
+        # Tail was flushed to the client before the close was raised.
+        handler.send_frames.assert_called_once_with([b"final"])
+        self.assertEqual([], handler.cqueue)
+
+    def test_eof_logs_target_closed_not_client(self):
+        handler, target = self._eof_handler(cqueue=[])
+
+        self.assertRaises(
+            FakeCClose,
+            handler._handle_ins_outs,
+            target, [target], [],
+        )
+
+        # Regression: the EOF branch used to log "Client closed connection".
+        logged = handler.msg.call_args[0][0]
+        self.assertIn("Target closed connection", logged)
+        self.assertNotIn("Client closed", logged)

--- a/zun/websocket/k8s_remotecommand.py
+++ b/zun/websocket/k8s_remotecommand.py
@@ -1,0 +1,49 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""Kubernetes remotecommand channel framing relayed by the wsproxy.
+
+Each binary WebSocket message is one frame: the first byte is the channel
+number, the rest is the payload.
+"""
+
+from enum import IntEnum
+
+
+class Channel(IntEnum):
+    # The single source of truth for the remotecommand channel-byte values.
+    STDIN = 0
+    STDOUT = 1
+    STDERR = 2
+    ERROR = 3
+    RESIZE = 4
+
+
+def frame_from_client(data):
+    """Wrap client stdin bytes in a stdin-channel frame."""
+    return bytes((Channel.STDIN,)) + data
+
+
+def payload_for_client(frame):
+    """Return the bytes to write to the client, or None to drop the frame.
+
+    Forward only stdout/stderr; drop the channel byte, the error/status frame,
+    resize, and empty frames so none of them reach the terminal.
+
+    This combines stdout and stderr into one stream.
+    """
+    if not frame:
+        return None
+    channel, payload = frame[0], frame[1:]
+    if channel in (Channel.STDOUT, Channel.STDERR) and payload:
+        return payload
+    return None

--- a/zun/websocket/websocketproxy.py
+++ b/zun/websocket/websocketproxy.py
@@ -139,14 +139,41 @@ class ZunProxyRequestHandlerBase(object):
             # Receive target data, encode it and queue for client
             buf = target.recv()
             if len(buf) == 0:
-                self.msg(_("Client closed connection:"
-                           "%(host)s:%(port)s") % {
+                # Target hit EOF: flush queued output before closing so the
+                # tail of the stream is not dropped.
+                self._drain_cqueue_to_client()
+                self.msg(_("Target closed connection: %(host)s:%(port)s") % {
                     'host': self.server.target_host,
                     'port': self.server.target_port})
                 raise self.CClose(1000, "Target closed")
             if isinstance(buf, str):
                 buf = buf.encode()
             self.cqueue.append(buf)
+
+    def _drain_cqueue_to_client(self, timeout=2.0):
+        """Flush any queued client-bound output before closing.
+
+        On target EOF we must push whatever is still in self.cqueue to the
+        client; otherwise the tail of the stream is lost (the normal send
+        branch only runs when select reports the client writable, which may
+        not happen in the pass that delivers EOF). Honor backpressure: if
+        send_frames reports the client can't absorb it all, wait for the
+        socket to become writable and retry, bounded by ``timeout`` so a dead
+        client can't hang the worker.
+        """
+        deadline = time.time() + timeout
+        while self.cqueue or self.c_pend:
+            # send_frames flushes cqueue + any internally-pending parts.
+            self.c_pend = self.send_frames(self.cqueue)
+            self.cqueue = []
+            if not self.c_pend:
+                break
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            _, writable, _ = select.select([], [self.request], [], remaining)
+            if not writable:
+                break  # client gone / stalled; give up rather than hang
 
     def _prefix_payload(self, channel, payload):
         if self.channels and channel in self.channels:

--- a/zun/websocket/websocketproxy.py
+++ b/zun/websocket/websocketproxy.py
@@ -326,6 +326,16 @@ class ZunProxyRequestHandlerBase(object):
 
         self._verify_origin(access_url)
 
+        # Prevent replay attacks by deleting the exec instance row. This is
+        # important because the k8s backend invokes the command when the
+        # websocket connects, and unlike the docker backend, doesn't internally
+        # prevent the same command from being invoked multiple times.
+        # A DB row-lock prevents multiple processes/threads from claiming the
+        # same exec instance.
+        # TODO(chameleon): Periodically prune unclaimed execinstance rows.
+        if not exec_instance.destroy(_admin_context()):
+            raise exception.InvalidWebsocketToken(token)
+
         client = docker.APIClient(base_url=exec_instance.url)
         tsock = client.exec_start(exec_id, socket=True, tty=True)
         if hasattr(tsock, "_sock"):

--- a/zun/websocket/websocketproxy.py
+++ b/zun/websocket/websocketproxy.py
@@ -38,6 +38,7 @@ from zun.common.i18n import _
 from zun.compute import api as compute_api
 import zun.conf
 from zun import objects
+from zun.websocket import k8s_remotecommand
 from zun.websocket.websocketclient import WebSocketClient
 
 LOG = logging.getLogger(__name__)
@@ -51,8 +52,9 @@ def _admin_context():
 def _write_sock_optfile(contents):
     """Write some config file to storage.
 
-    This is useful for libraries that require some configuration be read from a file,
-    yet we receive all websocket options via RPC transport as raw text.
+    This is useful for libraries that require some configuration be read
+    from a file, yet we receive all websocket options via RPC transport as
+    raw text.
     """
     if not contents:
         return None
@@ -61,6 +63,7 @@ def _write_sock_optfile(contents):
     if not path.exists():
         path.write_text(contents)
     return path.absolute()
+
 
 class ZunProxyRequestHandlerBase(object):
     compute_api: "compute_api.API" = None
@@ -129,7 +132,7 @@ class ZunProxyRequestHandlerBase(object):
 
         if target in outs:
             while self.tqueue:
-                payload = self._prefix_payload('stdin', self.tqueue.pop(0))
+                payload = self._prefix_payload(self.tqueue.pop(0))
                 remaining = self._send_buffer(payload, target)
                 if remaining is not None:
                     self.tqueue.appendleft(remaining)
@@ -148,7 +151,9 @@ class ZunProxyRequestHandlerBase(object):
                 raise self.CClose(1000, "Target closed")
             if isinstance(buf, str):
                 buf = buf.encode()
-            self.cqueue.append(buf)
+            buf = self._demux_payload(buf)
+            if buf:
+                self.cqueue.append(buf)
 
     def _drain_cqueue_to_client(self, timeout=2.0):
         """Flush any queued client-bound output before closing.
@@ -175,13 +180,22 @@ class ZunProxyRequestHandlerBase(object):
             if not writable:
                 break  # client gone / stalled; give up rather than hang
 
-    def _prefix_payload(self, channel, payload):
-        if self.channels and channel in self.channels:
-            return chr(self.channels[channel]).encode('ascii') + payload
-        else:
-            return payload
+    def _prefix_payload(self, payload):
+        """Frame stdin coming from client and going to a backend."""
+        if self.framed:
+            return k8s_remotecommand.frame_from_client(payload)
+        return payload
 
-    def do_websocket_proxy(self, target, channels=None):
+    def _demux_payload(self, payload):
+        """Demux a frame from a backend and split into stdout,stderr channels.
+
+        For unframed backends (docker) the payload passes through unchanged.
+        """
+        if self.framed:
+            return k8s_remotecommand.payload_for_client(payload)
+        return payload
+
+    def do_websocket_proxy(self, target, framed=False):
         """Proxy websocket link
 
         Proxy client WebSocket to normal target socket.
@@ -189,7 +203,7 @@ class ZunProxyRequestHandlerBase(object):
         self.cqueue = []
         self.tqueue = []
         self.c_pend = 0
-        self.channels = channels
+        self.framed = framed
         rlist = [self.request, target]
 
         if self.server.heartbeat:
@@ -264,10 +278,43 @@ class ZunProxyRequestHandlerBase(object):
         else:
             self._new_websocket_client(container, token, uuid)
 
-        # TODO: here is where we could perhaps trigger a quick websocket resize
-        # to an already open client, if exec_id is not specified AND resize is given
-        # in the request. It should just connect and immediately send the request,
-        # then send a client disconnect? Or maybe the other end should disconnect :p
+        # TODO(chameleon): here is where we could perhaps trigger a quick
+        # websocket resize to an already open client, if exec_id is not
+        # specified AND resize is given in the request. It should just connect
+        # and immediately send the request, then send a client disconnect? Or
+        # maybe the other end should disconnect :p
+
+    def _proxy_native_websocket(self, container, target_url):
+        try:
+            ws_opts = self.compute_api.container_get_websocket_opts(
+                _admin_context(), container)
+        except Exception:
+            LOG.exception("failed to get websocket options")
+            # Only zun-compute agents supporting API >=1.2 have this method.
+            ws_opts = {}
+
+        options = {}
+        if "ca" in ws_opts or "cert" in ws_opts or "key" in ws_opts:
+            options["sslopt"] = {
+                "certfile": _write_sock_optfile(ws_opts.get("cert")),
+                "keyfile": _write_sock_optfile(ws_opts.get("key")),
+                "ca_certs": _write_sock_optfile(ws_opts.get("ca")),
+            }
+        wscls = WebSocketClient(host_url=target_url, escape="~",
+                                close_wait=0.5, **options)
+        wscls.connect()
+        self.target = wscls
+
+        framed = bool(ws_opts.get("channels"))
+
+        # Start proxying
+        try:
+            self.do_websocket_proxy(self.target.ws, framed=framed)
+        except Exception:
+            if self.target.ws:
+                self.target.ws.close()
+                self.vmsg(_("Websocket client or target closed"))
+            raise
 
     def _new_websocket_client(self, container, token, uuid):
         if token != container.websocket_token:
@@ -278,39 +325,10 @@ class ZunProxyRequestHandlerBase(object):
 
         self._verify_origin(access_url)
 
-        if container.websocket_url:
-            target_url = container.websocket_url
-            escape = "~"
-            close_wait = 0.5
-            try:
-                ws_opts = self.compute_api.container_get_websocket_opts(
-                    _admin_context(), container)
-            except Exception as e:
-                LOG.exception("failed to get websocket options")
-                # Only zun-compute agents supporting API >=1.2 have this method.
-                ws_opts = {}
-            options = {}
-            if "ca" in ws_opts or "cert" in ws_opts or "key" in ws_opts:
-                options["sslopt"] = {
-                    "certfile": _write_sock_optfile(ws_opts.get("cert")),
-                    "keyfile": _write_sock_optfile(ws_opts.get("key")),
-                    "ca_certs": _write_sock_optfile(ws_opts.get("ca")),
-                }
-            wscls = WebSocketClient(host_url=target_url, escape=escape,
-                                    close_wait=close_wait, **options)
-            wscls.connect()
-            self.target = wscls
-        else:
+        if not container.websocket_url:
             raise exception.InvalidWebsocketUrl()
 
-        # Start proxying
-        try:
-            self.do_websocket_proxy(self.target.ws, channels=ws_opts.get("channels"))
-        except Exception:
-            if self.target.ws:
-                self.target.ws.close()
-                self.vmsg(_("Websocket client or target closed"))
-            raise
+        self._proxy_native_websocket(container, container.websocket_url)
 
     def _new_exec_client(self, container, token, uuid, exec_id):
         exec_instance = None
@@ -335,6 +353,11 @@ class ZunProxyRequestHandlerBase(object):
         # TODO(chameleon): Periodically prune unclaimed execinstance rows.
         if not exec_instance.destroy(_admin_context()):
             raise exception.InvalidWebsocketToken(token)
+
+        # Url returned for k8s backend already starts with websocket
+        if exec_instance.url.startswith(("ws://", "wss://")):
+            self._proxy_native_websocket(container, exec_instance.url)
+            return
 
         client = docker.APIClient(base_url=exec_instance.url)
         tsock = client.exec_start(exec_id, socket=True, tty=True)


### PR DESCRIPTION
Zun supports two modes of command exec in a container.

When run=true, the command is executed synchronously, and the result returned in a HTTP response.
When run=false, the command is queued for execution in an "ExecInstance" object, and run in response to a later API call. This allows stdin and stdout to be streamed to the client via websocket.

The original semantics mirror docker's exec_create and exec_run. To make this work for k8s, we need to store the command to run in the ExecInstance, and generate a unique ID to look it up.

Several changes are necessary due to the format of k8s's remotecommand API.
1. The command is passed via url params, and so we need to store a longer URL for the exec instance in the DB
2. the command is executed when the k8s websocket connects, so we need to prevent concurrent or duplicate executions of the same command by getting a row lock
3. terminal resize events are sent in-band on the websocket, instead of via a separate API. implementing this is a TODO, because we would need to have zun-api receive the current resize request api, look up the correct websocket proxy, send the request over RPC, and have the websocket proxy inject the resize frame into the websocket.